### PR TITLE
開発コンテナのリビルド時に増えるパッケージの削除

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -19,3 +19,5 @@ go get -v\
   golang.org/x/tools/cmd/goimports  \
   golang.org/x/lint/golint  \
   golang.org/x/tools/gopls  
+
+go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/bwmarrin/discordgo v0.22.0
-	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 )


### PR DESCRIPTION
## 関連するチケット
* #4 

## やったこと
* `$ go get` で増えてしまうパッケージを`$ go mod tidy` で削除するようにした。
* ついでに現時点で必要なgo.modの状態にした。

## みること
* リビルドしてもgo.modに余計なものが無くて、ちゃんと動けばok