### PR TITLE
Bot経由でゲームサーバのステータスを確認したい

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,14 +3,14 @@ package config
 type Config struct {
 	StartTriggerMessage     string
 	HibernateTriggerMessage string
-	GetStatusMessage        string
+	GetStatusTriggerMessage string
 }
 
 func GetConfig() (Config, error) {
 	config := Config{
 		StartTriggerMessage:     "start",
 		HibernateTriggerMessage: "sleep",
-		GetStatusMessage:        "status",
+		GetStatusTriggerMessage: "status",
 	}
 	return config, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,12 +3,14 @@ package config
 type Config struct {
 	StartTriggerMessage     string
 	HibernateTriggerMessage string
+	GetStatusMessage        string
 }
 
 func GetConfig() (Config, error) {
 	config := Config{
 		StartTriggerMessage:     "start",
 		HibernateTriggerMessage: "sleep",
+		GetStatusMessage:        "status",
 	}
 	return config, nil
 }

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 		log.Println("正常終了 : インスタンス停止")
 		targetChannel.messageSend("インスタンスの停止に成功")
 
-	} else if event.Content == messages.GetStatusMessage {
+	} else if event.Content == messages.GetStatusTriggerMessage {
 		// 起動状態の確認(IPアドレスの取得)
 		log.Println("開始 : インスタンスステータス確認")
 		targetChannel.messageSend("インスタンスの確認コマンドを検知")

--- a/main.go
+++ b/main.go
@@ -40,28 +40,71 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 	}
 
 	if event.Content == messages.StartTriggerMessage {
-		log.Println("Start Instance")
+		// 起動時
+		log.Println("開始 : インスタンス起動...")
 		outputJSON, err := exec.Command("aws", "ec2", "start-instances", "--instance-ids", os.Getenv("INSTANCE_ID")).Output()
 		if err != nil {
-			log.Fatalln(err)
+			log.Println("起動に失敗した :", err)
+			return
 		}
 
 		startResponse := StartResponse{}
 		if err := json.Unmarshal(outputJSON, &startResponse); err != nil {
-			log.Fatalln(err)
+			log.Println("起動時のレスポンスに異常 :", err)
+			return
+		}
+		currentState := startResponse.StartingInstances[0].CurrentState.Name
+		if currentState == "running" {
+			log.Println("既に起動している")
+			return
 		}
 
+		previousState := startResponse.StartingInstances[0].PreviousState.Name
+		if currentState == "pending" && previousState == "pending" {
+			log.Println("起動処理実行中")
+			return
+		}
+
+		// 開始待ち
+		if _, err := exec.Command("aws", "ec2", "wait", "instance-running", "--instance-ids", os.Getenv("INSTANCE_ID")).Output(); err != nil {
+			log.Println("起動待ちに失敗した :", err)
+			return
+		}
+		log.Println("正常停止 : インスタンス起動")
+
 	} else if event.Content == messages.HibernateTriggerMessage {
-		log.Println("Hibernate Instance")
+		// 停止時
+		log.Println("開始 : インスタンス停止...")
 		outputJSON, err := exec.Command("aws", "ec2", "stop-instances", "--instance-ids", os.Getenv("INSTANCE_ID")).Output()
 		if err != nil {
-			log.Fatalln(err)
+			log.Println("停止に失敗した :", err)
+			return
 		}
 
 		stopResponse := StopResponse{}
 		if err := json.Unmarshal(outputJSON, &stopResponse); err != nil {
-			log.Fatalln(err)
+			log.Println("停止時のレスポンスに異常 :", err)
+			return
 		}
+
+		currentState := stopResponse.StoppingInstances[0].CurrentState.Name
+		if currentState == "stopped" {
+			log.Println("既に停止している")
+			return
+		}
+
+		previousState := stopResponse.StoppingInstances[0].PreviousState.Name
+		if currentState == "stopping" && previousState == "stopping" {
+			log.Println("停止処理実行中")
+			return
+		}
+
+		// 停止待ち
+		if _, err := exec.Command("aws", "ec2", "wait", "instance-stopped", "--instance-ids", os.Getenv("INSTANCE_ID")).Output(); err != nil {
+			log.Println("停止待ちに失敗した :", err)
+			return
+		}
+		log.Println("正常停止 : インスタンス停止")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -189,6 +189,24 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 
 		log.Println("正常終了 : インスタンス停止")
 		targetChannel.messageSend("インスタンスの停止に成功")
+
+	} else if event.Content == messages.GetStatusMessage {
+		// 起動状態の確認(IPアドレスの取得)
+		log.Println("開始 : インスタンスステータス確認")
+		targetChannel.messageSend("インスタンスの確認コマンドを検知")
+
+		ipaddress, err := getIPAddress()
+		if err != nil {
+			targetChannel.messageSend("インスタンスの確認に失敗")
+			return
+		}
+
+		if ipaddress != "" {
+			targetChannel.messageSend("インスタンスは起動済み :" + ipaddress)
+		} else {
+			targetChannel.messageSend("インスタンスは未起動")
+		}
+
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -61,6 +61,26 @@ func (tc *TargetChannel) messageSend(message string) error {
 	return nil
 }
 
+// getIPAddress インスタンスのIPアドレス取得
+func getIPAddress() (string, error) {
+	statusOutputJSON, err := exec.Command("aws", "ec2", "describe-instances", "--instance-ids", os.Getenv("INSTANCE_ID"), "--query", "Reservations[].Instances[].{publicip:PublicIpAddress}").Output()
+	if err != nil {
+		log.Println("IPアドレス取得時、コマンド実行に失敗 : ", err)
+		return "", err
+	}
+
+	ssResponse := []ServerStatusRespose{}
+	if err := json.Unmarshal(statusOutputJSON, &ssResponse); err != nil {
+		log.Println("IPアドレス取得時のレスポンスに異常 :", err)
+		return "", err
+	}
+
+	ipaddress := ssResponse[0].Publicip
+	log.Println("IPアドレス : ", ipaddress)
+
+	return ipaddress, nil
+}
+
 func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 	targetChannel := TargetChannel{
 		s:     s,
@@ -119,22 +139,13 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 		targetChannel.messageSend("約1分後、IPアドレス通知予定")
 		time.Sleep(time.Minute)
 
-		statusOutputJSON, err := exec.Command("aws", "ec2", "describe-instances", "--instance-ids", os.Getenv("INSTANCE_ID"), "--query", "Reservations[].Instances[].{publicip:PublicIpAddress}").Output()
+		ipaddress, err := getIPAddress()
 		if err != nil {
-			log.Println("IPアドレス取得時、コマンド実行に失敗 : ", err)
 			targetChannel.messageSend("IPアドレスの取得に失敗")
 			return
 		}
 
-		ssResponse := []ServerStatusRespose{}
-		if err := json.Unmarshal(statusOutputJSON, &ssResponse); err != nil {
-			log.Println("IPアドレス取得時のレスポンスに異常 :", err)
-			targetChannel.messageSend("IPアドレスの取得に失敗")
-			return
-		}
-
-		log.Println("IPアドレス : ", ssResponse[0].Publicip)
-		targetChannel.messageSend("今回のIPアドレス : " + ssResponse[0].Publicip)
+		targetChannel.messageSend("今回のIPアドレス : " + ipaddress)
 
 	} else if event.Content == messages.HibernateTriggerMessage {
 		// 停止時

--- a/main.go
+++ b/main.go
@@ -33,6 +33,28 @@ type InstanceStatus struct {
 	} `json:"PreviousState"`
 }
 
+// TargetChannel Botがメッセージを投稿するDiscordチャンネル
+type TargetChannel struct {
+	s     *discordgo.Session
+	event *discordgo.MessageCreate
+}
+
+func (tc *TargetChannel) messageSend(message string) error {
+	// コマンドが投稿されたチャンネル
+	targetChannel, err := tc.s.State.Channel(tc.event.ChannelID)
+	if err != nil {
+		log.Println("チャンネルの取得に失敗 :", err)
+		return err
+	}
+
+	// Botからメッセージ投稿
+	if _, err := tc.s.ChannelMessageSend(targetChannel.ID, message); err != nil {
+		log.Println("チャンネルメッセージの送信に失敗 :", err)
+		return err
+	}
+	return nil
+}
+
 func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 	messages, err := config.GetConfig()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+// ServerStatusRespose EC2起動後のステータス確認レスポンス
+type ServerStatusRespose struct {
+	Publicip string `json:"publicip"`
+}
+
 // StartResponse EC2起動指示時のレスポンス
 type StartResponse struct {
 	StartingInstances []InstanceStatus `json:"StartingInstances"`

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 			log.Println("起動待ちに失敗した :", err)
 			return
 		}
-		log.Println("正常停止 : インスタンス起動")
+		log.Println("正常終了 : インスタンス起動")
 
 	} else if event.Content == messages.HibernateTriggerMessage {
 		// 停止時
@@ -104,7 +104,7 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 			log.Println("停止待ちに失敗した :", err)
 			return
 		}
-		log.Println("正常停止 : インスタンス停止")
+		log.Println("正常終了 : インスタンス停止")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -76,7 +76,9 @@ func getIPAddress() (string, error) {
 	}
 
 	ipaddress := ssResponse[0].Publicip
-	log.Println("IPアドレス : ", ipaddress)
+	if ipaddress != "" {
+		log.Println("IPアドレス : ", ipaddress)
+	}
 
 	return ipaddress, nil
 }


### PR DESCRIPTION
## 関連するチケット等
* #3 
* #7

## やったこと
* IPアドレス取得部を分離して、単体で使えるようにした

## みること
* `status`メッセージでIPアドレスを確認する
* 既存の`start`メッセージに影響がないことを確認する

## 備考
* #7 の続きに書いてます
* 最後の4コミットが今回の変更箇所です。