### PR TITLE
インスタンス起動時のIP取得までの待機時間が長い

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,8 +138,7 @@ func receive(s *discordgo.Session, event *discordgo.MessageCreate) {
 
 		// IPアドレス通知
 		log.Println("IPアドレス取得待機中...")
-		targetChannel.messageSend("約1分後、IPアドレス通知予定")
-		time.Sleep(time.Minute)
+		time.Sleep(time.Second)
 
 		ipaddress, err := getIPAddress()
 		if err != nil {


### PR DESCRIPTION
## 関連するチケット
* #13 

## やったこと
* IPアドレス取得までの待機時間を1分 -> 1秒にした

## 確認すること
* この待機時間でもIPアドレス取得が成功すること
  * 多分だいじょうぶ

## 備考
* 試してみたところ、起動後即取得しようとしなければエラーにはならなかった。
* issueでは5秒としているが1秒でも問題ないと判断。
  * これに合わせて、IPアドレス取得待機時のメッセージを削除している。