### PR TITLE
開発コンテナのrootユーザに権限を持っていかれる現象に対処

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "bot",
+	"remoteUser": "gopher",
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/src/hansel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM golang:1.15.6-buster
 
+ARG USERNAME=gopher
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash  --uid $USER_UID --gid $USER_GID -m $USERNAME 
+
 RUN apt update \
   && apt upgrade -y \
   && apt install -y less unzip
+  
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \


### PR DESCRIPTION
## 概要
* 開発コンテナにファイル権限を持っていかれないようにひっそりと修正。
* 開発コンテナにユーザを追加した。
* 開発コンテナで作成したファイルでも、ホストOSからさわれるようになった。

## 備考
* 該当するContainer, Image等を削除の上、リポジトリをクローンしなおしてお試しください。